### PR TITLE
Add serialisation/deserialisation for components and models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +191,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rawpointer",
+ "serde",
 ]
 
 [[package]]
@@ -326,6 +337,8 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -451,6 +464,7 @@ dependencies = [
  "pythonize",
  "rscm-core",
  "serde",
+ "typetag",
 ]
 
 [[package]]
@@ -460,6 +474,7 @@ dependencies = [
  "is_close",
  "log",
  "nalgebra",
+ "ndarray",
  "num",
  "numpy",
  "ode_solvers",
@@ -469,6 +484,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "typetag",
 ]
 
 [[package]]
@@ -590,6 +606,7 @@ dependencies = [
 name = "two-layer-model"
 version = "0.1.0"
 dependencies = [
+ "ndarray",
  "numpy",
  "ode_solvers",
  "pyo3",
@@ -598,13 +615,44 @@ dependencies = [
  "rscm-components",
  "rscm-core",
  "serde",
+ "typetag",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "typetag"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ba3b6e86ffe0054b2c44f2d86407388b933b16cb0a70eea3929420db1d9bbe"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "typetag",
 ]
 
@@ -547,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "simba"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +610,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -739,3 +783,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 ode_solvers = "0.4.0"
+ndarray = { version = "*", features = ["serde"] }
 numpy = "0.21.0"
 rscm-core = { path = "rscm-core" }
 rscm-components = { path = "rscm-components" }
 pythonize = "0.21.1"
 serde = { version = "1.0.210", features = ["derive"] }
+typetag = "0.2"
 
 
 [dependencies.pyo3]

--- a/notebooks/coupled_model.py
+++ b/notebooks/coupled_model.py
@@ -293,6 +293,3 @@ as_scmrun(model.timeseries()).filter(variable="Cumulative *", keep=False).line_p
 # * Hierachy of timeseries / n box timeseries
 # * Better hinting of required parameters
 # * Parameter handling
-# * Serialisation/deserialisation (
-
-# %%

--- a/notebooks/helpers/__init__.py
+++ b/notebooks/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper modules for the notebooks."""

--- a/notebooks/helpers/models.py
+++ b/notebooks/helpers/models.py
@@ -1,0 +1,92 @@
+"""
+Common model builders
+"""
+
+import numpy as np
+
+from two_layer_model.components import CarbonCycleBuilder, CO2ERFBuilder
+from two_layer_model.core import (
+    InterpolationStrategy,
+    ModelBuilder,
+    TimeAxis,
+    Timeseries,
+)
+
+
+def example_model_builder(t_initial, t_final) -> ModelBuilder:
+    """
+    Build a simple coupled model with a carbon cycle and CO2 ERF component
+
+    Parameters
+    ----------
+    t_initial
+        Start year
+    t_final
+        End year
+
+    Returns
+    -------
+        Model builder with the components and exogenous variables set up
+    """
+    time_axis = TimeAxis.from_values(
+        np.concat(
+            [np.arange(t_initial, 2015.0, 5), np.arange(2015.0, t_final + 1, 1.0)]
+        )
+    )
+    tau = 20.3
+    conc_pi = 280.0
+    erf_2xco2 = 4.0
+    alpha_temperature = 0.0  # Have no temperature feedback
+
+    # %%
+    co2_erf_component = CO2ERFBuilder.from_parameters(
+        dict(erf_2xco2=erf_2xco2, conc_pi=conc_pi)
+    ).build()
+    carbon_cycle_component = CarbonCycleBuilder.from_parameters(
+        dict(tau=tau, conc_pi=conc_pi, alpha_temperature=alpha_temperature)
+    ).build()
+
+    initial_state = {
+        "Cumulative Land Uptake": 0.0,
+        "Cumulative Emissions|CO2": 0.0,
+        "Atmospheric Concentration|CO2": 300.0,
+    }
+
+    step_year = 1850.0
+    step_size = 10.0
+
+    emissions = Timeseries(
+        np.asarray([0.0, 0.0, step_size, step_size]),
+        TimeAxis.from_bounds(
+            np.asarray(
+                [
+                    t_initial,
+                    (t_initial + step_year) / 2.0,
+                    step_year,
+                    step_year + 50.0,
+                    t_final,
+                ]
+            )
+        ),
+        "GtC / yr",
+        InterpolationStrategy.Previous,
+    )
+
+    surface_temp = Timeseries(
+        np.asarray([0.42]),
+        TimeAxis.from_bounds(np.asarray([float(t_initial), float(t_final)])),
+        "K",
+        InterpolationStrategy.Previous,
+    )
+
+    model = (
+        ModelBuilder()
+        .with_rust_component(carbon_cycle_component)
+        .with_rust_component(co2_erf_component)
+        .with_time_axis(time_axis)
+        .with_exogenous_variable("Surface Temperature", surface_temp)
+        .with_exogenous_variable("Emissions|CO2|Anthropogenic", emissions)
+        .with_initial_values(initial_state)
+    )
+
+    return model

--- a/notebooks/state_serialisation.py
+++ b/notebooks/state_serialisation.py
@@ -13,8 +13,13 @@
 # ---
 
 # %% [markdown]
-# # State serialisation
+# # Model state serialisation
 #
+# It can be useful to be able to be able to capture the current state of a model
+# and serialise it for later use.
+#
+# We provide an TOML representation of a model's state that provides a human-readable
+# description of the model, including its components and state.
 
 # %%
 from helpers.models import example_model_builder
@@ -22,17 +27,99 @@ from helpers.models import example_model_builder
 from two_layer_model._lib.core import Model
 
 # %%
-
+# Create a simple example coupled model with some exogenous data
 model = example_model_builder(1750, 2100).build()
+
+# %%
+# We can then step the model forward in time
 model.step()
 model.step()
 
 # %% [markdown]
-# We can log the state of a model using JSON.
-
-serialised_model = model.to_json()
-serialised_model
+# We can log the state of a model using TOML.
+#
+# This format is human-readable and can be used to store the state of a model to disk.
+# A binary-format could be used to store the state of a model in a more compact way.
+#
 
 # %%
-new_model = Model.from_json(serialised_model)
-new_model
+serialised_model = model.to_toml()
+print(serialised_model)
+
+# %% [markdown]
+# ## Recreating the model state
+#
+# A new model can be initialised using the TOML represenation.
+# The new model will have the same state and components as the original model
+
+# %%
+new_model = Model.from_toml(serialised_model)
+print(new_model.as_dot())
+
+# %% [markdown]
+# It will also on the same timestep as the original model.
+
+# %%
+assert new_model.current_time() == model.current_time()
+
+# %% [markdown]
+# The newly created model can then be run as normal.
+
+# %%
+new_model.run()
+
+# %% [markdown]
+# Currently we don't provide many hooks to modify the state of the model post-creation.
+# A `Model` configuration is effectively immutable after creation.
+#
+# A `ModelBuilder` could be created using the contents of the model state to enable
+# modification or to provide the initial conditions for a later run.
+# The common use case that we are aiming to support is to be able to spin a model up
+# over a historical period with a given set of parameters,
+# and then run multiple different future scenarios with the same parameters.
+#
+# The historical period does not need to be run for every scenario.
+# Instead a model can be created from the state of the historical model and run with
+# the new scenario data for the future period.
+
+# %% [markdown]
+# Some psuedo-code that illustrates the desired operation is shown below:
+#
+# ```py
+# historical_time_axis = TimeAxis.from_values(np.arange(1850, 2015 + 1))
+# scenario_time_axis = TimeAxis.from_values(np.arange(2015, 2100))
+# historical_exogenous_data: TimeseriesCollection = get_historical_data()
+#
+#
+# model_builder = get_builder_with_components()
+#
+# historical_model = (
+#     get_builder_with_components()
+#     .with_time_axis(historical_time_axis)
+#     .with_exogenous_collection(historical_exogenous_data)
+# ).build()
+#
+# historical_model.run()
+#
+# historical_model_state = historical_model.to_toml()
+#
+# # This state can be archived for later use
+#
+# for scenario in get_list_of_scenarios():
+#     model = (
+#         ModelBuilder
+#         .from_model_state(historical_model_state)
+#         # Some components may require more than one previous timestep
+#         # so we should merge time axes rather than dropping the historical data
+#         .with_time_axis(scenario_time_axis.merge(historical_time_axis))
+#         .with_current_time_step(2015.0)
+#         .with_exogenous_collection(scenario)
+#     ).build()
+#
+#     model.run()
+#
+#     # Save results
+# ```
+#
+
+# %%

--- a/notebooks/state_serialisation.py
+++ b/notebooks/state_serialisation.py
@@ -1,0 +1,38 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # State serialisation
+#
+
+# %%
+from helpers.models import example_model_builder
+
+from two_layer_model._lib.core import Model
+
+# %%
+
+model = example_model_builder(1750, 2100).build()
+model.step()
+model.step()
+
+# %% [markdown]
+# We can log the state of a model using JSON.
+
+serialised_model = model.to_json()
+serialised_model
+
+# %%
+new_model = Model.from_json(serialised_model)
+new_model

--- a/python/two_layer_model/_lib/core.pyi
+++ b/python/two_layer_model/_lib/core.pyi
@@ -240,3 +240,10 @@ class Model:
         -------
         Clone of the timeseries held by the model
         """
+
+    def to_json(self) -> str:
+        pass
+
+    @classmethod
+    def from_json(cls: type[T], serialised_model: str) -> T:
+        pass

--- a/python/two_layer_model/_lib/core.pyi
+++ b/python/two_layer_model/_lib/core.pyi
@@ -241,9 +241,30 @@ class Model:
         Clone of the timeseries held by the model
         """
 
-    def to_json(self) -> str:
-        pass
+    def to_toml(self) -> str:
+        """
+        Serialise the current state of the model to a TOML string.
+
+        This string can be used to recreate the model at a later time using
+        `~Model.from_toml`.
+
+        Returns
+        -------
+        String representation of the model, including the state required to recreate
+        the model at a later time.
+        """
 
     @classmethod
-    def from_json(cls: type[T], serialised_model: str) -> T:
-        pass
+    def from_toml(cls: type[T], serialised_model: str) -> T:
+        """
+        Create a model from a TOML string.
+
+        Parameters
+        ----------
+        serialised_model
+            TOML string representing the model
+
+        Returns
+        -------
+        New model object with the state as defined in the TOML string.
+        """

--- a/python/two_layer_model/core.py
+++ b/python/two_layer_model/core.py
@@ -4,6 +4,7 @@ Core classes and functions for Rust Simple Climate Models (RSCMs)
 
 from two_layer_model._lib.core import (
     InterpolationStrategy,
+    Model,
     ModelBuilder,
     PythonComponent,
     RequirementDefinition,
@@ -18,6 +19,7 @@ __all__ = [
     "InterpolationStrategy",
     "RequirementDefinition",
     "RequirementType",
+    "Model",
     "ModelBuilder",
     "TimeAxis",
     "Timeseries",

--- a/rscm-components/Cargo.toml
+++ b/rscm-components/Cargo.toml
@@ -13,6 +13,7 @@ rscm-core = { path = "../rscm-core" }
 pythonize = "0.21.1"
 ode_solvers = "0.4.0"
 serde = { version = "1.0.210", features = ["derive"] }
+typetag = "0.2"
 
 [dev-dependencies]
 numpy = "0.21.0"

--- a/rscm-components/src/components/carbon_cycle.rs
+++ b/rscm-components/src/components/carbon_cycle.rs
@@ -6,12 +6,12 @@ use rscm_core::component::{
 use rscm_core::errors::RSCMResult;
 use rscm_core::ivp::{get_last_step, IVPBuilder, IVP};
 use rscm_core::timeseries::{FloatValue, Time};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 type ModelState = Vector3<FloatValue>;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CarbonCycleParameters {
     /// Timescale of the box's response
     /// unit: yr
@@ -25,12 +25,12 @@ pub struct CarbonCycleParameters {
 }
 
 // TODO: Move this into core
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SolverOptions {
     pub step_size: FloatValue,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CarbonCycleComponent {
     parameters: CarbonCycleParameters,
     solver_options: SolverOptions,
@@ -52,6 +52,7 @@ impl CarbonCycleComponent {
     }
 }
 
+#[typetag::serde]
 impl Component for CarbonCycleComponent {
     fn definitions(&self) -> Vec<RequirementDefinition> {
         vec![

--- a/rscm-components/src/components/co2_erf.rs
+++ b/rscm-components/src/components/co2_erf.rs
@@ -3,9 +3,9 @@ use rscm_core::component::{
 };
 use rscm_core::errors::RSCMResult;
 use rscm_core::timeseries::{FloatValue, Time};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CO2ERFParameters {
     /// ERF due to a doubling of atmospheric CO_2 concentrations
     /// unit: W / m^2
@@ -15,7 +15,7 @@ pub struct CO2ERFParameters {
     pub conc_pi: FloatValue,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 /// CO2 effective radiative forcing (ERF) calculations
 pub struct CO2ERF {
     parameters: CO2ERFParameters,
@@ -27,6 +27,7 @@ impl CO2ERF {
     }
 }
 
+#[typetag::serde]
 impl Component for CO2ERF {
     fn definitions(&self) -> Vec<RequirementDefinition> {
         vec![

--- a/rscm-components/tests/coupled_models.rs
+++ b/rscm-components/tests/coupled_models.rs
@@ -84,7 +84,7 @@ fn test_carbon_cycle() {
 
     model.run();
 
-    let co2_conc = model
+    let _co2_conc = model
         .timeseries()
         .get_timeseries_by_name("Atmospheric Concentration|CO2")
         .unwrap();
@@ -93,7 +93,7 @@ fn test_carbon_cycle() {
         .timeseries()
         .get_timeseries_by_name("Emissions|CO2|Anthropogenic")
         .unwrap();
-    let expected_concentrations: Vec<FloatValue> = time_axis
+    let _expected_concentrations: Vec<FloatValue> = time_axis
         .values()
         .iter()
         .map(|t| match *t < step_year {

--- a/rscm-core/Cargo.toml
+++ b/rscm-core/Cargo.toml
@@ -16,7 +16,6 @@ numpy = "0.21.0"
 nalgebra = "0.32.6"
 petgraph = { version = "0.6.5", features = ["serde-1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = "1.0"
 typetag = "0.2"
 log = "0.4"
 num = "0.4"
@@ -25,8 +24,10 @@ thiserror = "1.0"
 pythonize = "0.21.1"
 toml = "0.8.19"
 
-
 [dependencies.pyo3]
 version = "0.21.0"
 # "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
 features = ["abi3-py38", "multiple-pymethods"]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/rscm-core/Cargo.toml
+++ b/rscm-core/Cargo.toml
@@ -9,13 +9,15 @@ categories = ["science"]
 workspace = ".."
 
 [dependencies]
-numpy = "0.21.0"
 ode_solvers = "0.4.0"
+ndarray = { version = "*", features = ["serde-1"] }
+numpy = "0.21.0"
 # Pin nlgebra until new release of ode_solvers
 nalgebra = "0.32.6"
-petgraph = "0.6.5"
-serde = { version = "1.0", features = ["derive"] }
+petgraph = { version = "0.6.5", features = ["serde-1"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+typetag = "0.2"
 log = "0.4"
 num = "0.4"
 is_close = "0.1"

--- a/rscm-core/Cargo.toml
+++ b/rscm-core/Cargo.toml
@@ -23,6 +23,7 @@ num = "0.4"
 is_close = "0.1"
 thiserror = "1.0"
 pythonize = "0.21.1"
+toml = "0.8.19"
 
 
 [dependencies.pyo3]

--- a/rscm-core/src/component.rs
+++ b/rscm-core/src/component.rs
@@ -150,7 +150,7 @@ impl RequirementDefinition {
 /// * outputs: Information that is solved by the component
 
 #[typetag::serde(tag = "type")]
-pub trait Component: Debug {
+pub trait Component: Debug + Send + Sync {
     fn definitions(&self) -> Vec<RequirementDefinition>;
 
     /// Variables that are required to solve this component

--- a/rscm-core/src/component.rs
+++ b/rscm-core/src/component.rs
@@ -111,6 +111,7 @@ pub enum RequirementType {
     Input,
     Output,
     InputAndOutput, // TODO: Figure out how to compose input and output together
+    EmptyLink,
 }
 
 #[pyclass]

--- a/rscm-core/src/component.rs
+++ b/rscm-core/src/component.rs
@@ -2,6 +2,7 @@ use crate::errors::RSCMResult;
 use crate::timeseries::{FloatValue, Time};
 use crate::timeseries_collection::{TimeseriesCollection, VariableType};
 use pyo3::pyclass;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::iter::zip;
@@ -105,7 +106,7 @@ impl IntoIterator for InputState {
 pub type OutputState = InputState;
 
 #[pyclass]
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub enum RequirementType {
     Input,
     Output,
@@ -113,7 +114,7 @@ pub enum RequirementType {
 }
 
 #[pyclass]
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct RequirementDefinition {
     #[pyo3(get, set)]
     pub name: String,
@@ -148,6 +149,7 @@ impl RequirementDefinition {
 ///   components as part of a coupled system or from exogenous data.
 /// * outputs: Information that is solved by the component
 
+#[typetag::serde(tag = "type")]
 pub trait Component: Debug {
     fn definitions(&self) -> Vec<RequirementDefinition>;
 

--- a/rscm-core/src/component.rs
+++ b/rscm-core/src/component.rs
@@ -149,7 +149,11 @@ impl RequirementDefinition {
 /// * inputs: State information required to solve the model. This come from either other
 ///   components as part of a coupled system or from exogenous data.
 /// * outputs: Information that is solved by the component
-
+///
+/// Structs implementing the `Component` trait should be serializable and deserializable
+/// and use the `#[typetag::serde]` macro when implementing the trait to enable
+/// serialisation/deserialisation when using `Component` as an object trait
+/// (i.e. where `dyn Component` is used; see `models.rs`).
 #[typetag::serde(tag = "type")]
 pub trait Component: Debug + Send + Sync {
     fn definitions(&self) -> Vec<RequirementDefinition>;

--- a/rscm-core/src/example_components.rs
+++ b/rscm-core/src/example_components.rs
@@ -6,14 +6,14 @@ use crate::component::{
 use crate::errors::RSCMResult;
 use crate::timeseries::{FloatValue, Time};
 use crate::timeseries_collection::TimeseriesCollection;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TestComponentParameters {
     pub p: FloatValue,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TestComponent {
     parameters: TestComponentParameters,
 }
@@ -24,6 +24,7 @@ impl TestComponent {
     }
 }
 
+#[typetag::serde]
 impl Component for TestComponent {
     fn definitions(&self) -> Vec<RequirementDefinition> {
         vec![

--- a/rscm-core/src/model.rs
+++ b/rscm-core/src/model.rs
@@ -9,7 +9,10 @@
 /// The model also holds all of the exogenous variables required by the model.
 /// The required variables are identified when building the model.
 /// If a required exogenous variable isn't provided, then the build step will fail.
-use crate::component::{Component, InputState, RequirementDefinition, State};
+use crate::component::{
+    Component, InputState, OutputState, RequirementDefinition, RequirementType, State,
+};
+use crate::errors::RSCMResult;
 use crate::interpolate::strategies::{InterpolationStrategy, LinearSplineStrategy};
 use crate::timeseries::{FloatValue, Time, TimeAxis, Timeseries};
 use crate::timeseries_collection::{TimeseriesCollection, VariableType};
@@ -24,6 +27,7 @@ use std::ops::Index;
 use std::sync::Arc;
 
 type C = Arc<dyn Component>;
+type CGraph = Graph<C, RequirementDefinition>;
 
 #[derive(Debug)]
 struct VariableDefinition {
@@ -37,6 +41,28 @@ impl VariableDefinition {
             name: definition.name.clone(),
             unit: definition.unit.clone(),
         }
+    }
+}
+
+/// A null component that does nothing
+///
+/// Used as an initial component to ensure that the model is connected
+#[derive(Debug, Serialize, Deserialize)]
+struct NullComponent {}
+
+#[typetag::serde]
+impl Component for NullComponent {
+    fn definitions(&self) -> Vec<RequirementDefinition> {
+        vec![]
+    }
+
+    fn solve(
+        &self,
+        _t_current: Time,
+        _t_next: Time,
+        input_state: &InputState,
+    ) -> RSCMResult<OutputState> {
+        Ok(OutputState::from(input_state.clone()))
     }
 }
 
@@ -171,14 +197,14 @@ impl ModelBuilder {
     /// Panics if the required data to build a model is not available.
     pub fn build(&self) -> Model {
         // todo: refactor once this is more stable
-        let mut graph: Graph<Option<C>, Option<RequirementDefinition>> = Graph::new();
+        let mut graph: CGraph = Graph::new();
         let mut endrogoneous: HashMap<String, NodeIndex> = HashMap::new();
         let mut exogenous: Vec<String> = vec![];
         let mut definitions: HashMap<String, VariableDefinition> = HashMap::new();
-        let initial_node = graph.add_node(Option::None);
+        let initial_node = graph.add_node(Arc::new(NullComponent {}));
 
         self.components.iter().for_each(|component| {
-            let node = graph.add_node(Option::from(component.clone()));
+            let node = graph.add_node(component.clone());
             let mut has_dependencies = false;
 
             let requires = component.inputs();
@@ -189,11 +215,7 @@ impl ModelBuilder {
 
                 if exogenous.contains(&requirement.name) {
                     // Link to the node that provides the requirement
-                    graph.add_edge(
-                        endrogoneous[&requirement.name],
-                        node,
-                        Option::from(requirement.clone()),
-                    );
+                    graph.add_edge(endrogoneous[&requirement.name], node, requirement.clone());
                     has_dependencies = true;
                 } else {
                     // Add a new variable that must be defined outside of the model
@@ -206,7 +228,11 @@ impl ModelBuilder {
                 // create a link to the initial node.
                 // This ensures that we have a single connected graph
                 // There might be smarter ways to iterate over the nodes, but this is fine for now
-                graph.add_edge(initial_node, node, None);
+                graph.add_edge(
+                    initial_node,
+                    node,
+                    RequirementDefinition::new("", "", RequirementType::EmptyLink),
+                );
             }
 
             provides.iter().for_each(|requirement| {
@@ -219,9 +245,7 @@ impl ModelBuilder {
                         endrogoneous.insert(requirement.name.clone(), node);
                     }
                     Some(node_index) => {
-                        println!("Duplicate definition of {:?} requirement", requirement.name);
-
-                        graph.add_edge(*node_index, node, Option::from(requirement.clone()));
+                        graph.add_edge(*node_index, node, requirement.clone());
                         endrogoneous.insert(requirement.name.clone(), node);
                     }
                 }
@@ -264,7 +288,7 @@ impl ModelBuilder {
                                 .interpolate_into(self.time_axis.clone()),
                             VariableType::Exogenous,
                         ),
-                        None => panic!("No exogenous data for {}", definition.name),
+                        None => println!("No exogenous data for {}", definition.name),
                     }
                 }
             } else {
@@ -312,7 +336,7 @@ pub struct Model {
     /// between nodes.
     /// This graph is traversed on every time step to ensure that any state dependencies are
     /// solved before another component needs the state.
-    components: Graph<Option<C>, Option<RequirementDefinition>>,
+    components: CGraph,
     /// The base node of the graph from where to begin traversing.
     initial_node: NodeIndex,
     /// The model state
@@ -326,7 +350,7 @@ pub struct Model {
 
 impl Model {
     pub fn new(
-        components: Graph<Option<C>, Option<RequirementDefinition>>,
+        components: CGraph,
         initial_node: NodeIndex,
         collection: TimeseriesCollection,
         time_axis: Arc<TimeAxis>,
@@ -384,11 +408,7 @@ impl Model {
         let mut bfs = Bfs::new(&self.components, self.initial_node);
         while let Some(nx) = bfs.next(&self.components) {
             let c = self.components.index(nx);
-
-            if c.is_some() {
-                let c = c.as_ref().unwrap().clone();
-                self.step_model_component(c)
-            }
+            self.step_model_component(c.clone())
         }
     }
 
@@ -412,21 +432,12 @@ impl Model {
     /// Create a diagram the represents the component graph
     ///
     /// Useful for debugging
-    pub fn as_dot(&self) -> Dot<&Graph<Option<C>, Option<RequirementDefinition>>> {
+    pub fn as_dot(&self) -> Dot<&CGraph> {
         Dot::with_attr_getters(
             &self.components,
             &[Config::NodeNoLabel, Config::EdgeNoLabel],
-            &|_, er| {
-                let requirement = er.weight();
-                match requirement {
-                    None => "".to_string(),
-                    Some(r) => format!("label = {:?}", r.name),
-                }
-            },
-            &|_, (_, component)| match component {
-                None => "".to_string(),
-                Some(c) => format!("label = \"{:?}\"", c),
-            },
+            &|_, er| format!("label = {:?}", er.weight().name),
+            &|_, (_, component)| format!("label = \"{:?}\"", component),
         )
     }
 
@@ -445,8 +456,10 @@ mod tests {
     use super::*;
     use crate::example_components::{TestComponent, TestComponentParameters};
     use crate::interpolate::strategies::PreviousStrategy;
+    use is_close::is_close;
     use numpy::array;
     use numpy::ndarray::Array;
+    use std::iter::zip;
 
     fn get_emissions() -> Timeseries<FloatValue> {
         Timeseries::new(
@@ -514,5 +527,101 @@ mod tests {
 
         let res = format!("{:?}", model.as_dot());
         assert_eq!(res, exp);
+    }
+
+    #[test]
+    fn serialise_and_deserialise_model() {
+        let mut model = ModelBuilder::new()
+            .with_time_axis(TimeAxis::from_values(Array::range(2020.0, 2025.0, 1.0)))
+            .with_component(Arc::new(TestComponent::from_parameters(
+                TestComponentParameters { p: 0.5 },
+            )))
+            .with_exogenous_variable("Emissions|CO2", get_emissions())
+            .build();
+
+        model.step();
+
+        let serialised = serde_json::to_string_pretty(&model).unwrap();
+        println!("{}", serialised);
+        let serialised = toml::to_string(&model).unwrap();
+
+        let expected = r#"initial_node = 0
+time_index = 1
+
+[components]
+node_holes = []
+edge_property = "directed"
+edges = [[0, 1, { name = "", unit = "", requirement_type = "EmptyLink" }]]
+
+[[components.nodes]]
+type = "NullComponent"
+
+[[components.nodes]]
+type = "TestComponent"
+
+[components.nodes.parameters]
+p = 0.5
+
+[[collection.timeseries]]
+name = "Concentrations|CO2"
+variable_type = "Endogenous"
+
+[collection.timeseries.timeseries]
+units = "ppm"
+latest = 1
+interpolation_strategy = "Linear"
+
+[collection.timeseries.timeseries.values]
+v = 1
+dim = [5]
+data = [nan, 0.65, nan, nan, nan]
+
+[collection.timeseries.timeseries.time_axis.bounds]
+v = 1
+dim = [6]
+data = [2020.0, 2021.0, 2022.0, 2023.0, 2024.0, 2025.0]
+
+[[collection.timeseries]]
+name = "Emissions|CO2"
+variable_type = "Exogenous"
+
+[collection.timeseries.timeseries]
+units = "GtC / yr"
+latest = 5
+interpolation_strategy = "Previous"
+
+[collection.timeseries.timeseries.values]
+v = 1
+dim = [5]
+data = [10.0, 10.0, 10.0, 10.0, 10.0]
+
+[collection.timeseries.timeseries.time_axis.bounds]
+v = 1
+dim = [6]
+data = [2020.0, 2021.0, 2022.0, 2023.0, 2024.0, 2025.0]
+
+[time_axis.bounds]
+v = 1
+dim = [6]
+data = [2020.0, 2021.0, 2022.0, 2023.0, 2024.0, 2025.0]
+"#;
+
+        assert_eq!(serialised, expected);
+
+        let deserialised = toml::from_str::<Model>(&serialised).unwrap();
+
+        assert!(zip(
+            model
+                .collection
+                .get_timeseries_by_name("Emissions|CO2")
+                .unwrap()
+                .values(),
+            deserialised
+                .collection
+                .get_timeseries_by_name("Emissions|CO2")
+                .unwrap()
+                .values()
+        )
+        .all(|(x0, x1)| { is_close!(*x0, *x1) || (x0.is_nan() && x0.is_nan()) }))
     }
 }

--- a/rscm-core/src/model.rs
+++ b/rscm-core/src/model.rs
@@ -518,12 +518,12 @@ mod tests {
             .with_exogenous_variable("Emissions|CO2", get_emissions())
             .build();
 
-        let exp = "digraph {
-    0 [ ]
-    1 [ label = \"TestComponent { parameters: TestComponentParameters { p: 0.5 } }\"]
-    0 -> 1 [ ]
+        let exp = r#"digraph {
+    0 [ label = "NullComponent"]
+    1 [ label = "TestComponent { parameters: TestComponentParameters { p: 0.5 } }"]
+    0 -> 1 [ label = ""]
 }
-";
+"#;
 
         let res = format!("{:?}", model.as_dot());
         assert_eq!(res, exp);
@@ -622,6 +622,9 @@ data = [2020.0, 2021.0, 2022.0, 2023.0, 2024.0, 2025.0]
                 .unwrap()
                 .values()
         )
-        .all(|(x0, x1)| { is_close!(*x0, *x1) || (x0.is_nan() && x0.is_nan()) }))
+        .all(|(x0, x1)| { is_close!(*x0, *x1) || (x0.is_nan() && x0.is_nan()) }));
+
+        assert_eq!(model.current_time_bounds(), (2021.0, 2022.0));
+        assert_eq!(deserialised.current_time_bounds(), (2021.0, 2022.0));
     }
 }

--- a/rscm-core/src/model.rs
+++ b/rscm-core/src/model.rs
@@ -18,11 +18,12 @@ use petgraph::dot::{Config, Dot};
 use petgraph::graph::NodeIndex;
 use petgraph::visit::{Bfs, IntoNeighbors, IntoNodeIdentifiers, Visitable};
 use petgraph::Graph;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Index;
 use std::sync::Arc;
 
-type C = Arc<dyn Component + Send + Sync>;
+type C = Arc<dyn Component>;
 
 #[derive(Debug)]
 struct VariableDefinition {
@@ -305,7 +306,7 @@ impl Default for ModelBuilder {
 /// then a CO_2 concentration timeseries must be defined externally.
 /// If the model also contains a carbon cycle component which produced CO_2 concentrations,
 /// then the ERF component will be solved after the carbon cycle model.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Model {
     /// A directed graph with components as nodes and the edges defining the state dependencies
     /// between nodes.

--- a/rscm-core/src/python/model.rs
+++ b/rscm-core/src/python/model.rs
@@ -124,18 +124,18 @@ impl PyModel {
     ///
     /// This includes the components, their internal state and the model's
     /// state.
-    fn to_json(&self) -> PyResult<String> {
-        let serialised = serde_json::to_string(&self.0);
+    fn to_toml(&self) -> PyResult<String> {
+        let serialised = toml::to_string(&self.0);
         match serialised {
             Ok(serialised) => Ok(serialised),
             Err(e) => Err(PyValueError::new_err(format!("{}", e))),
         }
     }
 
-    /// Initialise a model from a JSON representation
+    /// Initialise a model from a TOML representation
     #[staticmethod]
-    fn from_json(string: String) -> PyResult<Self> {
-        let deserialised = serde_json::from_str::<Model>(string.as_str());
+    fn from_toml(string: String) -> PyResult<Self> {
+        let deserialised = toml::from_str::<Model>(string.as_str());
         match deserialised {
             Ok(deserialised) => Ok(PyModel(deserialised)),
             Err(e) => Err(PyValueError::new_err(format!("{}", e))),

--- a/rscm-core/src/timeseries.rs
+++ b/rscm-core/src/timeseries.rs
@@ -5,7 +5,7 @@ use nalgebra::max;
 use num::{Float, ToPrimitive};
 use numpy::ndarray::prelude::*;
 use numpy::ndarray::{Array, Array1, ViewRepr};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::iter::zip;
 use std::sync::Arc;
 
@@ -188,15 +188,6 @@ impl TimeAxis {
     }
 }
 
-/// A helper to deserialize `f64`, treating JSON null as f64::NAN.
-/// See https://github.com/serde-rs/json/issues/202
-fn deserialize_float_null_as_nan<'de, D: Deserializer<'de>>(
-    des: D,
-) -> Result<FloatValue, D::Error> {
-    let optional = Option::<FloatValue>::deserialize(des)?;
-    Ok(optional.unwrap_or(FloatValue::NAN))
-}
-
 /// A contiguous set of values
 ///
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -205,7 +196,6 @@ where
     T: Float,
 {
     units: String,
-    #[serde(deserialize_with = "deserialize_float_null_as_nan")]
     values: Array1<T>,
     // Using a reference counted time axis to avoid having to maintain multiple clones of the
     // time axis.
@@ -407,6 +397,7 @@ where
 mod tests {
     use super::*;
     use crate::interpolate::strategies::{InterpolationStrategy, PreviousStrategy};
+    use is_close::is_close;
 
     #[test]
     #[should_panic]
@@ -449,5 +440,73 @@ mod tests {
             .with_interpolation_strategy(InterpolationStrategy::from(PreviousStrategy::new(true)));
         let result = timeseries.at_time(query).unwrap();
         assert_eq!(result, 2.0);
+    }
+
+    #[test]
+    fn serialise_and_deserialise_json() {
+        let data = array![1.0, 1.5, 2.0];
+        let years = Array::range(2020.0, 2023.0, 1.0);
+
+        let timeseries = Timeseries::from_values(data, years);
+
+        let serialised = serde_json::to_string(&timeseries).unwrap();
+        assert_eq!(
+            serialised,
+            r#"{"units":"","values":{"v":1,"dim":[3],"data":[1.0,1.5,2.0]},"time_axis":{"bounds":{"v":1,"dim":[4],"data":[2020.0,2021.0,2022.0,2023.0]}},"latest":3,"interpolation_strategy":"Linear"}"#
+        );
+
+        let deserialised = serde_json::from_str::<Timeseries<f64>>(&serialised).unwrap();
+
+        assert_eq!(timeseries.values(), deserialised.values());
+    }
+
+    #[test]
+    #[should_panic]
+    fn serialise_and_deserialise_with_nan_json() {
+        let data = array![1.0, 1.5, FloatValue::nan()];
+        let years = Array::range(2020.0, 2023.0, 1.0);
+
+        let timeseries = Timeseries::from_values(data, years);
+
+        let serialised = serde_json::to_string(&timeseries).unwrap();
+        assert_eq!(
+            serialised,
+            r#"{"units":"","values":{"v":1,"dim":[3],"data":[1.0,1.5,null]},"time_axis":{"bounds":{"v":1,"dim":[4],"data":[2020.0,2021.0,2022.0,2023.0]}},"latest":2,"interpolation_strategy":"Linear"}"#
+        );
+
+        // This panics as it can't handle null -> NaN values
+        serde_json::from_str::<Timeseries<f64>>(&serialised).unwrap();
+    }
+
+    #[test]
+    fn serialise_and_deserialise_with_nan_toml() {
+        let data = array![1.0, 1.5, FloatValue::nan()];
+        let years = Array::range(2020.0, 2023.0, 1.0);
+
+        let timeseries = Timeseries::from_values(data, years);
+
+        let serialised = toml::to_string(&timeseries).unwrap();
+
+        let expected = "units = \"\"
+latest = 2
+interpolation_strategy = \"Linear\"
+
+[values]
+v = 1
+dim = [3]
+data = [1.0, 1.5, nan]
+
+[time_axis.bounds]
+v = 1
+dim = [4]
+data = [2020.0, 2021.0, 2022.0, 2023.0]
+";
+
+        assert_eq!(serialised, expected);
+
+        let deserialised = toml::from_str::<Timeseries<f64>>(&serialised).unwrap();
+
+        assert!(zip(timeseries.values(), deserialised.values())
+            .all(|(x0, x1)| { is_close!(*x0, *x1) || (x0.is_nan() && x0.is_nan()) }))
     }
 }

--- a/rscm-core/src/timeseries.rs
+++ b/rscm-core/src/timeseries.rs
@@ -5,6 +5,7 @@ use nalgebra::max;
 use num::{Float, ToPrimitive};
 use numpy::ndarray::prelude::*;
 use numpy::ndarray::{Array, Array1, ViewRepr};
+use serde::{Deserialize, Serialize};
 use std::iter::zip;
 use std::sync::Arc;
 
@@ -18,7 +19,7 @@ pub type Time = f64;
 /// This is a placeholder to make it easier to be able to use a generic representation of value.
 pub type FloatValue = f64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimeAxis {
     bounds: Array1<Time>,
 }
@@ -189,7 +190,7 @@ impl TimeAxis {
 
 /// A contiguous set of values
 ///
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Timeseries<T>
 where
     T: Float,

--- a/rscm-core/src/timeseries_collection.rs
+++ b/rscm-core/src/timeseries_collection.rs
@@ -1,6 +1,7 @@
 use crate::timeseries::{FloatValue, Timeseries};
+use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[pyo3::pyclass]
 pub enum VariableType {
     /// Values that are defined outside of the model
@@ -9,7 +10,7 @@ pub enum VariableType {
     Endogenous,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeseriesItem {
     pub timeseries: Timeseries<FloatValue>,
     pub name: String,
@@ -18,7 +19,7 @@ pub struct TimeseriesItem {
 
 /// A collection of time series data.
 /// Allows for easy access to time series data by name across the whole model
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeseriesCollection {
     timeseries: Vec<TimeseriesItem>,
 }

--- a/rscm-core/src/timeseries_collection.rs
+++ b/rscm-core/src/timeseries_collection.rs
@@ -55,6 +55,8 @@ impl TimeseriesCollection {
             name,
             variable_type,
         });
+        // Ensure the order of the serialised timeseries is stable
+        self.timeseries.sort_unstable_by_key(|x| x.name.clone());
     }
 
     pub fn get_by_name(&self, name: &str) -> Option<&TimeseriesItem> {

--- a/src/two_layer.rs
+++ b/src/two_layer.rs
@@ -9,12 +9,12 @@ use rscm_core::component::{
 use rscm_core::errors::RSCMResult;
 use rscm_core::ivp::{IVPBuilder, IVP};
 use rscm_core::timeseries::{FloatValue, Time};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // Define some types that are used by OdeSolvers
 type ModelState = Vector3<FloatValue>;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TwoLayerComponentParameters {
     pub lambda0: FloatValue,
     pub a: FloatValue,
@@ -24,7 +24,7 @@ pub struct TwoLayerComponentParameters {
     pub heat_capacity_deep: FloatValue,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TwoLayerComponent {
     parameters: TwoLayerComponentParameters,
 }
@@ -67,6 +67,7 @@ impl TwoLayerComponent {
     }
 }
 
+#[typetag::serde]
 impl Component for TwoLayerComponent {
     fn definitions(&self) -> Vec<RequirementDefinition> {
         vec![

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,8 @@
 import numpy as np
+import numpy.testing as npt
 
 from two_layer_model._lib import TwoLayerComponentBuilder
-from two_layer_model._lib.core import InterpolationStrategy, Timeseries
+from two_layer_model._lib.core import InterpolationStrategy, Model, Timeseries
 from two_layer_model.core import ModelBuilder
 
 
@@ -37,3 +38,45 @@ def test_model(time_axis):
     print(model.as_dot())
 
     model.run()
+
+
+def test_model_serialisation(time_axis):
+    component = TwoLayerComponentBuilder.from_parameters(
+        dict(
+            lambda0=0.0,
+            a=0.0,
+            efficacy=0.0,
+            eta=0.0,
+            heat_capacity_deep=0.0,
+            heat_capacity_surface=0.0,
+        )
+    ).build()
+
+    builder = ModelBuilder()
+    builder.with_time_axis(time_axis).with_rust_component(component)
+    erf = Timeseries(
+        np.asarray([1.0] * len(time_axis)),
+        time_axis,
+        "W / m^2",
+        InterpolationStrategy.Next,
+    )
+
+    model = builder.with_exogenous_variable("Effective Radiative Forcing", erf).build()
+
+    model.step()
+
+    serialised_model = model.to_toml()
+
+    new_model = Model.from_toml(serialised_model)
+
+    assert new_model.as_dot() == model.as_dot()
+    assert new_model.current_time() == model.current_time()
+
+    # Run the rest of the model and verify that the results are the same
+    model.run()
+    new_model.run()
+
+    npt.assert_allclose(
+        new_model.timeseries().get_timeseries_by_name("Surface Temperature").values(),
+        model.timeseries().get_timeseries_by_name("Surface Temperature").values(),
+    )

--- a/tests/test_timeseries_collection.py
+++ b/tests/test_timeseries_collection.py
@@ -7,7 +7,7 @@ class TestTimeseriesCollection:
         collection.add_timeseries("Test", timeseries, VariableType.Exogenous)
         collection.add_timeseries("Other", timeseries, VariableType.Endogenous)
 
-        assert repr(collection) == '<TimeseriesCollection names=["Test", "Other"]>'
+        assert repr(collection) == '<TimeseriesCollection names=["Other", "Test"]>'
 
     def test_timeseries(self, timeseries):
         collection = TimeseriesCollection()


### PR DESCRIPTION
## Description

Adds serialisation of models.

TOML was chosen as an output format as it provides human-readable for nested data and JSON failed to be able to deserialize timeseries with NaN's in it without additional effort. `serde_json` converts the NaN to a `null`, but then when deserialising the null causes a incorrect type error.

I couldn't see an easy fix for that so I moved on with life.

## Checklist

Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
- [x] `.pyi` files updated

Closes #3 
